### PR TITLE
Revert Embedded Slides

### DIFF
--- a/docs/source/presentations.md
+++ b/docs/source/presentations.md
@@ -2,58 +2,40 @@
 
 ## Theory lunch talks
 
-<iframe src="presentations/CosmaIntro.pdf" width="100%" height="500px"></iframe>
 [Theory Lunch talk: COSMA Introduction (20th May 2019)](presentations/CosmaIntro.pdf)
 
-<iframe src="presentations/Filesystems.pdf" width="100%" height="500px"></iframe>
 [Theory Lunch talk: Parallel File Systems (22nd July 2019)](presentations/Filesystems.pdf)
 
-<iframe src="presentations/Slurm.pdf" width="100%" height="500px"></iframe>
 [Theory Lunch talk: SLURM (9th September 2019)](presentations/Slurm.pdf)
 
-<iframe src="presentations/Modules.pdf" width="100%" height="500px"></iframe>
 [Theory Lunch talk: Modules (7th October 2019)](presentations/Modules.pdf)
 
-<iframe src="presentations/Debugging.pdf" width="100%" height="500px"></iframe>
 [Theory Lunch talk: Debugging (25th November 2019)](presentations/Debugging.pdf)
 
-<iframe src="presentations/TestDrivenDevelopment.pdf" width="100%" height="500px"></iframe>
 [Theory Lunch talk: Test Driven Development (24th February 2020)](presentations/TestDrivenDevelopment.pdf)
 
-<iframe src="presentations/hpcgate.pdf" width="100%" height="500px"></iframe>
 [Theory Lunch talk: HPC-gate recent HPC attacks (18th May 2020)](presentations/hpcgate.pdf)
 
-<iframe src="presentations/AI.pdf" width="100%" height="500px"></iframe>
 [Theory Lunch talk: AI on COSMA (18th May 2020) [identifying names removed]](presentations/AI.pdf)
 
-<iframe src="presentations/Spack.pdf" width="100%" height="500px"></iframe>
 [Theory Lunch talk: SPACK alternative to modules (13th July 2020)](presentations/Spack.pdf)
 
-<iframe src="presentations/UsefulInfo.pdf" width="100%" height="500px"></iframe>
 [Theory Lunch talk: Useful information (7th September 2020)](presentations/UsefulInfo.pdf)
 
-<iframe src="https://slides.com/aidansedgewick/june-712ea0/embed" width="100%" height="500px"></iframe>
 [Theory Lunch talk: JUNE: Modelling the spread of COVID-19 in the UK (2nd November 2020)](https://slides.com/aidansedgewick/june-712ea0)
 
-<iframe src="presentations/Cosma8.pdf" width="100%" height="500px"></iframe>
 [Theory Lunch talk: COSMA8 (25th January 2021)](presentations/Cosma8.pdf)
 
-<iframe src="https://slides.com/astrobyte/julia/embed" width="100%" height="500px"></iframe>
 [Theory Lunch talk: JULIA (29th March 2021)](https://slides.com/astrobyte/julia)
 
-<iframe src="presentations/ICCTalkApril2021Dirac-wilkinson.pdf" width="100%" height="500px"></iframe>
 [Theory Lunch talk: DiRAC-3 (26th April 2021)](presentations/ICCTalkApril2021Dirac-wilkinson.pdf)
 
-<iframe src="presentations/SwiftGalaxyDemo.ipynb.txt" width="100%" height="500px"></iframe>
 [Theory Lunch talk: SwiftSimIo (7th February 2022)](presentations/SwiftGalaxyDemo.ipynb.txt)
 
-<iframe src="https://slides.com/carolcuesta/deck-ec5b90/embed" width="100%" height="500px"></iframe>
 [Theory Lunch talk: JAX (7th March 2022)](https://slides.com/carolcuesta/deck-ec5b90) and [notebook](https://colab.research.google.com/drive/1FNY0qgeOWf-9lJKtmluD2Kml6j_osmDv?usp=sharing)
 
-<iframe src="presentations/GPUsApr22.odp" width="100%" height="500px"></iframe>
 [Theory Lunch talk: GPUs (4th April 2022)](presentations/GPUsApr22.odp)
 
 ## Postgraduate Lectures
 
-<iframe src="presentations/cosma2018.pdf" width="100%" height="500px"></iframe>
 [COSMA 2018](presentations/cosma2018.pdf)


### PR DESCRIPTION
The embedded slides page are not displaying the slides within the `<iframe>` tags. Because of incompatibility of files such as `.odp `,`.ipynp.txt`  and external sources. 