### PR TITLE
Hardwarelab Updates

### DIFF
--- a/docs/source/cpucomputelab.md
+++ b/docs/source/cpucomputelab.md
@@ -3,7 +3,7 @@
 The CPU Compute Lab provides access to latest generation CPU technologies, to enable code porting and optimisation by UK researchers in preparation for future large production systems.
 
 Current systems include
-- Sapphire Rapids (2024)
+- [Sapphire Rapids (2024)](#more-on-sapphire-rapids)
   - Direct ssh to the gi001 node
   - Via the dine2 Slurm partition
 - Bergamo (2023)
@@ -18,3 +18,41 @@ Current systems include
   - Via the cosma8-rome Slurm partition
 - CascadeLake (2019)
   - Via the cosma7-shm2 Slurm partition
+
+## More on Sapphire Rapids
+
+### Node access
+
+Our Sapphire Rapids are configured to hold Ponte Vecchio GPUs (PVCs). Therefore, they are accessible as part of our Intel GPU nodes.
+
+(*) The nodes are given out FCFS, i.e. please check prior to any benchmarking that nobody else is currently using the node.
+
+### Specification
+
+- CPU name:       Intel(R) Xeon(R) Platinum 8480+
+- Sockets:                2
+- Cores per socket:       56
+- Threads per core:       2
+
+### Environment
+
+As this is an Intel node while Cosma's login nodes are AMD, we recommend to compile exclusively on the node:
+
+```sh
+module load intel_comp
+module load compiler-rt tbb compiler mpi
+```
+
+The module oneAPI should work as well.
+
+### Performance
+
+To assess the node's performance, we recommend to run
+
+```sh
+module load likwid
+likwid-bench
+```
+
+Type in -a or -h to see an overview of the available metrics. Stream Triad and peak are the ones we usually recommend to look at first.
+

--- a/docs/source/dine.md
+++ b/docs/source/dine.md
@@ -6,6 +6,12 @@ It is now in the second generation.
 
 To date, it has hosted BlueField-1, Rockport and BlueField-2 technologies.
 
+To request a Bluefield-2 DPU node, use `#SBATCH -p bluefield1`
+
+The Bluefield nodes are powered down when not in use, so when you submit your job you may see the status as `CF` (configuring) while your allocated nodes are booting.
+
+To see the status of the Bluefield-2 nodes, run `sinfo -p bluefield1`.
+
 # DINE2
 
 DINE2, the Durham Investigatory Node Environment (or Durham Integrated Next-gen Environment), is an 8 node cluster with dual Intel Sapphire Rapids 32-core processors and 2TB RAM.  Each node has access to up to 8 NVIDIA A30 GPUs, using a CerIO composable fabric.

--- a/docs/source/hardwarelab.md
+++ b/docs/source/hardwarelab.md
@@ -1,8 +1,10 @@
 # HPC Hardware Lab @Durham
 
-The [HPC Hardware Laboratory @Durham](https://durham.readthedocs.io/en/latest/hardwarelab) is used for prototyping and development of new systems and technologies.  Many of the systems tested are readily available for benchmarking.  Details of available nodes and GPUs can be found [here](hardwarelabsummary.md).
+The [HPC Hardware Laboratory @Durham](https://durham.readthedocs.io/en/latest/hardwarelab) is used for prototyping and development of new systems and technologies.
+It is hosted within, yet independent of the [COSMA HPC facility](https://cosma.readthedocs.io) and receives funding from Durham University, industry partners, UKRI (e.g. through [ExCALIBUR](https://excalibur.ac.uk/)) and [DiRAC](https://dirac.ac.uk/).
+Many of the systems tested are readily available for benchmarking.  Details of available nodes and GPUs can be found [here](hardwarelabsummary.md).
 
-To request access to any of the systems within the hardware lab, please [create an account](account.md) and request to join the corresponding [project code](gpu.md#project-codes).
+To request access to any of the systems within the hardware lab, please [create an account](account.md) and request to join the corresponding [project code](gpu.md#project-codes).  Please also contact Alastair Basden (a.g.basden@durham.ac.uk) or Tobias Weinzierl (tobias.weinzierl@durham.ac.uk) before you request an account, as we will have to review your request.
 
 The Hardware Lab features the following systems and technologies:  
 [DINE and DINE2](#dine-and-dine2)  
@@ -16,6 +18,7 @@ The Hardware Lab features the following systems and technologies:
 [Immersion Cooling](#immersion-cooling)  
 [Heat Storage](#heat-storage)  
 
+There are a number of other hardware lab facilities around the UK.  If you are looking for specific hardware which is not on this list, a good starting point to search for available facilities is the [collection maintained by the SHAREing project](https://shareing-dri.github.io/resources/).
 
 
 ## DINE and DINE2

--- a/docs/source/hardwarelab.md
+++ b/docs/source/hardwarelab.md
@@ -1,6 +1,21 @@
 # HPC Hardware Lab @Durham
 
-The [HPC Hardware Laboratory @Durham](https://durham.readthedocs.io/en/latest/hardwarelab) is used for prototyping and development of new systems and technologies.  Many of the systems tested are readily available for benchmarking.  A [summary is available](hardwarelabsummary.md). 
+The [HPC Hardware Laboratory @Durham](https://durham.readthedocs.io/en/latest/hardwarelab) is used for prototyping and development of new systems and technologies.  Many of the systems tested are readily available for benchmarking.  Details of available nodes and GPUs can be found [here](hardwarelabsummary.md).
+
+The Hardware Lab features the following systems and technologies:  
+[DINE and DINE2](#dine-and-dine2)  
+[GPU compute nodes](#gpu-compute)  
+[Composable Infrastructure](#composable-infrastructure)  
+[Rockport Network Fabric](#rockport-network-fabric)  
+[Quantum Annealing (DWAVE)](#dwave-quantum)  
+[CPU Compute Lab](#cpu-compute-lab)  
+[Storage Lab](#storage)  
+[Solar Power](#solar)  
+[Immersion Cooling](#immersion-cooling)  
+[Heat Storage](#heat-storage)  
+
+
+To request access to any of the systems within the hardware lab, please [create an account](account.md)
 
 ## DINE and DINE2
 
@@ -8,9 +23,9 @@ DINE and DINE2 are experimental test clusters for exploring new hardware and net
 
 ![DINE](images/dine.png)
 
-The [BlueField DPU cluster](bluefield.md), [DINE](dine.md), is equipped with 24 nodes each containing a NVIDIA BlueField-2 Data Processing Unit, with HDR200 InfiniBand connectivity.  To use this facility submit jobs to the bluefield1 Slurm partition.  It was previously equipped with BlueField1 and Rockport network cards.
+The [BlueField DPU cluster](bluefield.md), [DINE](dine.md), is equipped with 24 nodes, each containing a NVIDIA BlueField-2 Data Processing Unit, with HDR200 InfiniBand connectivity.  To use this facility, submit jobs to the bluefield1 Slurm partition.  It was previously equipped with BlueField1 and Rockport network cards.
 
-The [DINE2](dine.md) cluster is an 8 node cluster equipped with a CerIO composability fabric, allowing GPUs to be added to servers upon demand.
+The [DINE2](dine.md) cluster is an 8-node cluster equipped with a CerIO composability fabric, allowing GPUs to be added to servers upon demand.
 
 ## GPU compute
 
@@ -24,7 +39,7 @@ We have multiple generations of AMD MI GPU:
 - MI300A
 - MI300X
 
-There are [two nodes](amdgpu.md) each with two AMD MI200 GPUs available.  Submit jobs to the cosma8-shm2 partition.  This partition also contains a node with one AMD MI100 GPU.  To specify a particular GPU to submit to, use --exclude or --include.
+There are [two nodes](amdgpu.md), each with two AMD MI200 GPUs available.  Submit jobs to the cosma8-shm2 partition.  This partition also contains a node with one AMD MI100 GPU.  To specify a particular GPU to submit to, use --exclude or --include.
 
 For the MI300 GPUs, either submit to the mi300x queue, or ssh directly from a login node to the ga008 node (MI300X).
 

--- a/docs/source/hardwarelab.md
+++ b/docs/source/hardwarelab.md
@@ -2,6 +2,8 @@
 
 The [HPC Hardware Laboratory @Durham](https://durham.readthedocs.io/en/latest/hardwarelab) is used for prototyping and development of new systems and technologies.  Many of the systems tested are readily available for benchmarking.  Details of available nodes and GPUs can be found [here](hardwarelabsummary.md).
 
+To request access to any of the systems within the hardware lab, please [create an account](account.md) and request to join the corresponding [project code](gpu.md#project-codes).
+
 The Hardware Lab features the following systems and technologies:  
 [DINE and DINE2](#dine-and-dine2)  
 [GPU compute nodes](#gpu-compute)  
@@ -9,13 +11,12 @@ The Hardware Lab features the following systems and technologies:
 [Rockport Network Fabric](#rockport-network-fabric)  
 [Quantum Annealing (DWAVE)](#dwave-quantum)  
 [CPU Compute Lab](#cpu-compute-lab)  
-[Storage Lab](#storage)  
+[Storage Lab](#storage-lab)  
 [Solar Power](#solar)  
 [Immersion Cooling](#immersion-cooling)  
 [Heat Storage](#heat-storage)  
 
 
-To request access to any of the systems within the hardware lab, please [create an account](account.md)
 
 ## DINE and DINE2
 
@@ -25,7 +26,7 @@ DINE and DINE2 are experimental test clusters for exploring new hardware and net
 
 The [BlueField DPU cluster](bluefield.md), [DINE](dine.md), is equipped with 24 nodes, each containing a NVIDIA BlueField-2 Data Processing Unit, with HDR200 InfiniBand connectivity.  To use this facility, submit jobs to the bluefield1 Slurm partition.  It was previously equipped with BlueField1 and Rockport network cards.
 
-The [DINE2](dine.md) cluster is an 8-node cluster equipped with a CerIO composability fabric, allowing GPUs to be added to servers upon demand.
+The [DINE2](dine.md) cluster is an 8-node cluster equipped with a CerIO composability fabric, allowing GPUs to be added to servers upon demand.  To use the DINE2 cluster as a Hardware Lab user, apply to join the do015 project.
 
 ## GPU compute
 
@@ -49,11 +50,13 @@ V100, A100 and H100 nodes are [available for use](nvidiagpu.md), including Intel
 
 ### Intel GPU nodes
 
-A Ponte Vecchio GPU node is [available](intelgpu.md)
+A [Ponte Vecchio GPU](intelgpu.md) node was once available but is currently offline.
 
-### Tenstorrent Blackhole node
+### Tenstorrent Blackhole node (RISC-V)
 
-A Tenstorrent Blackhole server is [available](tenstorrent.md)
+A [Tenstorrent Blackhole](tenstorrent.md) server is available for interactive use, containing 4x Blackhole cards.  
+
+Tenstorrent cards are designed specifically for AI and machine-learning workloads, unlike GPUs which have been adapted over time from their original graphics rendering workloads.  Currently PyTorch, ONNX, and TensorFlow can be easily ported to Tenstorrent architecture, but software support is otherwise in the early stages of development.
 
 ## Composable infrastructure
 
@@ -73,7 +76,7 @@ The ExCALIBUR project funded [quantum annealing system access](quantum.md) via a
 
 A wide variety of [processor technologies](cpucomputelab.md) are available for testing and benchmarking and we try to maintain cutting-edge components.
 
-## Storage
+## Storage lab
 
 Our [storage laboratory](storagelab.md) includes prototype and production file systems of various types and technologies.
 

--- a/docs/source/tenstorrent.md
+++ b/docs/source/tenstorrent.md
@@ -8,7 +8,7 @@ It is a highly capable system for AI inferencing.
 
 ## Accessing the Tenstorrent system
 
-To access this system you need to join the do023 project, and then `ssh tenstorrent`.
+To access this system you need to join the do023 project, and then `ssh tenstorrent` from a login node.
 
 ## Usage of the Tenstorrent system
 


### PR DESCRIPTION
- Layout improvements to the main hardware lab page, adding a table of contents at the top of the page, as well as links to account creation and project codes.  More will follow on this point as it is a work in progress.

- Consolidated all information from the durham.readthedocs.io hardware lab pages, allowing the cosma site to become the single source of information.  I will submit a PR to the durham.readthedocs.io repo which redirects the hardware lab links to this site.

Thanks.