### PR TITLE
Align dine and dine2 pages with new template.

### DIFF
--- a/docs/source/bluefield.md
+++ b/docs/source/bluefield.md
@@ -1,9 +1,0 @@
-# BlueField DPU system
-
-A 24 node system equipped with 200G BlueField-2 Data Processing Units (NVIDIA) is available for testing the relevance of this technology for HPC.
-
-This is part of the [DINE](dine.md) cluster.
-
-## History
-
-An original 16-node BlueField-1 system was installed in 2019, and the success of this technology led to the development of the BlueField-2 system

--- a/docs/source/dine.md
+++ b/docs/source/dine.md
@@ -1,29 +1,29 @@
 # DINE
 
-The Durham Interconnected Novel Environment (DINE) is a test production cluster aimed at testing different HPC, networking and storage technologies.
-
-It is now in the second generation.
+The Durham Interconnected Novel Environment (DINE) is a test production cluster aimed at testing different HPC, networking and storage technologies.  It is now in the second generation.
 
 To date, it has hosted BlueField-1, Rockport and BlueField-2 technologies.
 
-To request a Bluefield-2 DPU node, use `#SBATCH -p bluefield1`
-
-The Bluefield nodes are powered down when not in use, so when you submit your job you may see the status as `CF` (configuring) while your allocated nodes are booting.
-
-To see the status of the Bluefield-2 nodes, run `sinfo -p bluefield1`.
-
-# DINE2
-
-DINE2, the Durham Investigatory Node Environment (or Durham Integrated Next-gen Environment), is an 8 node cluster with dual Intel Sapphire Rapids 32-core processors and 2TB RAM.  Each node has access to up to 8 NVIDIA A30 GPUs, using a CerIO composable fabric.
-
-To submit jobs to DINE2, use `#SBATCH -p dine2`.
-
-The GPU capability is undergoing testing, and details will follow here about how to access them.
-
-
-
-## History
-
 Installed in 2019, DINE was the first UK AMD Rome based production cluster.
 
-Installed in 2024, DINE-2 hosted a CerIO composable network fabric.
+## Specifications
+
+The DINE cluster consists of 24 nodes, each equipped with a 200G BlueField-2 Data Processing Unit from NVIDIA.
+DPUs offload networking and storage workloads from the main CPU of the node, separating infrastructure processing from job processing.
+
+| Nodes | RAM per node | CPU(s) | Network Technology |
+| --- | --- | --- | --- |
+| 24 | 512GB | 2x AMD EPYC 7302 16-Core | Infiniband |
+
+
+## Usage
+
+If you do not already have an account on COSMA, please follow the instructions [here](account.md), then request to join the project: do009.
+
+The DINE cluster is part of the `bluefield1` SLURM partition.  Jobs should be submitted to the queue using `#SBATCH -p bluefield1`.
+
+There is no direct ssh access to DINE nodes.
+
+## Known issues / notes
+
+The bluefield nodes are automatically powered down when not in use, so when you submit your job you may see the status as `CF` (configuring) while your allocated nodes are booting.

--- a/docs/source/dine2.md
+++ b/docs/source/dine2.md
@@ -1,0 +1,41 @@
+# DINE2
+
+DINE2, the Durham Investigatory Node Environment (or Durham Integrated Next-gen Environment), is an 8 node cluster with a CerIO composability fabric, allowing GPUs to be added to servers upon demand.
+
+With dual Intel Sapphire Rapids 32-core processors and 2TB RAM.  Each node has access to up to 8 NVIDIA A30 GPUs, using a CerIO composable fabric.
+
+## Specifications
+
+| Nodes | RAM per node | CPU(s) | Network Technology | GPU | GPU Count |
+| --- | --- | --- | --- | --- | --- |
+| 8 | 2TB | 2x Intel Sapphire Rapids 32-core | Infiniband | Nvidia A30 24GB | 8 Total (configurable) |
+
+By default, each node has a single GPU attached, but can be configured to use up to the 8 available.  
+To request a specific configuration, please contact `cosma-support@durham.ac.uk`.
+
+### Benchmarks
+
+- Memory bandwidth (BabelStream): 822 GB/s
+- array\_size: 134217728
+- iterations: 100
+- precision: FP64
+
+Futher details are available on the [SHAREing website](https://shareing-dri.github.io/hpc-testbeds/systems/cosma-a30/).
+
+## Usage
+
+If you do not already have an account on COSMA, please follow the instructions [here](account.md), then request to join the project: do015.
+
+The DINE2 cluster is part of the `dine2` SLURM partition.  Jobs should be submitted to the queue using `#SBATCH -p dine2`.
+
+There is no direct ssh access to DINE nodes.
+
+CUDA is available as a module, using `module load nvhpc/25.11`.
+
+## Known issues / notes
+
+Dine2 nodes mount /dine, not /cosma5.  Copy any necessary files into /dine/data/\<project\>/\<username\>/
+
+## History
+
+DINE2 was installed in 2024.

--- a/docs/source/gpu.md
+++ b/docs/source/gpu.md
@@ -64,6 +64,7 @@ To use a GPU available for direct login, just ssh to the node name given above.
 | PVC | 52.4 | 128 | 3280 |
 
 
+
 ## Using the composable A100 GPUs
 
 We have 3 NVIDIA A100 (40GB) GPUs, which can be moved (by software, in seconds, in theory!) between mad04, mad05 and mad06, hence the variable number above. If you have a particular requirement, please contact cosma-support. The default configuration is one GPU each (mad04,05,06). These GPUs are part of a composable PCIe fabric using a [Liqid](https://www.liqid.com) infrastructure funded as part of [ExCALIBUR](https://excalibur.ac.uk).  It is a good idea to add the ```nvidia-smi``` command to your batch script so that you can check that the GPUs are present.

--- a/docs/source/hardwarelab.md
+++ b/docs/source/hardwarelab.md
@@ -27,9 +27,11 @@ DINE and DINE2 are experimental test clusters for exploring new hardware and net
 
 ![DINE](images/dine.png)
 
-The [BlueField DPU cluster](bluefield.md), [DINE](dine.md), is equipped with 24 nodes, each containing a NVIDIA BlueField-2 Data Processing Unit, with HDR200 InfiniBand connectivity.  To use this facility, submit jobs to the bluefield1 Slurm partition.  It was previously equipped with BlueField1 and Rockport network cards.
+[DINE](dine.md), is equipped with 24 nodes, each containing a NVIDIA BlueField-2 Data Processing Unit, with HDR200 InfiniBand connectivity.  
+It was previously equipped with BlueField1 and Rockport network cards.
+To use this facility, join the do009 project and submit jobs to the `bluefield1` Slurm partition.  
 
-The [DINE2](dine.md) cluster is an 8-node cluster equipped with a CerIO composability fabric, allowing GPUs to be added to servers upon demand.  To use the DINE2 cluster as a Hardware Lab user, apply to join the do015 project.
+The [DINE2](dine2.md) cluster is an 8-node cluster equipped with a CerIO composability fabric, allowing GPUs to be added to servers upon demand.  To use the DINE2 cluster as a Hardware Lab user, apply to join the do015 project.
 
 ## GPU compute
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -98,8 +98,8 @@ Contents
 
    hardwarelab  
    rockportlab
-   bluefield
    dine
+   dine2
    cpucomputelab
    amdgpu
    nvidiagpu


### PR DESCRIPTION
- Dine page consolidated with bluefield page, updated to follow new template
- Dine2 page updated to follow new template, added benchmarks and link to SHAREing.
- index updated to add dine2, remove bluefield.
- hardwarelab page updated to use new links.