### PR TITLE
Update AMD GPU page

### DIFF
--- a/docs/source/amdgpu.md
+++ b/docs/source/amdgpu.md
@@ -1,5 +1,70 @@
 # AMD GPU testbeds
 
-COSMA contains multiple AMD GPU systems, including MI300X, MI300A, MI210, MI100 and MI50 GPUs, to allow code development, porting and performance benchmarking.
+COSMA contains multiple AMD GPU systems to allow code development, porting and performance benchmarking.
 
-More information is given on the [GPU pages](gpu.md)
+## Specifications
+
+### MI100 \([SHAREing](https://shareing-dri.github.io/hpc-testbeds/systems/cosma-mi100/)\)
+
+| Nodes | GPU | GPU Count | RAM per node | CPU(s) |
+| ----- | --- | --------- | ------------ | ------ |
+| 1 | AMD MI100 | 1 per node | 1TB | 2x AMD EPYC 7713 64-Core |
+
+Benchmarks:
+- Memory bandwidth (BabelStream): 947 GB/s
+- array\_size: 134217728
+- iterations: 100
+- precision: FP64
+
+### MI210 \([SHAREing](https://shareing-dri.github.io/hpc-testbeds/systems/cosma-mi210/)\)
+
+| Nodes | GPU | GPU Count | RAM per node | CPU(s) |
+| ----- | --- | --------- | ------------ | ------ |
+| 2 | AMD MI210 | 2 per node | 1TB | 2x AMD EPYC 7513 32-Core |
+
+Benchmarks:
+- Memory bandwidth (BabelStream): 1250 GB/s
+- array\_size: 134217728
+- iterations: 100
+- precision: FP64
+
+### MI300X \([SHAREing](https://shareing-dri.github.io/hpc-testbeds/systems/cosma-mi300x/)\)
+
+| Nodes | GPU | GPU Count | RAM per node | CPU(s) |
+| ----- | --- | --------- | ------------ | ------ |
+| 1 | AMD MI300X | 8 per node | 512GB | 2x Intel Xeon Platinum 8468 48-Core
+ |
+
+ Benchmarks:
+ - Memory bandwidth (BabelStream): 4036 GB/s
+ - array\_size: 134217728
+ - iterations: 100
+ - precision: FP64
+
+### MI300A \([SHAREing](https://shareing-dri.github.io/hpc-testbeds/systems/cosma-mi300a/)\)
+
+| Nodes | APU | RAM per node |
+| ----- | --- | ------------ |
+| 1 | 4x AMD MI300A (24 CPU cores) | 512GB |
+
+Benchmarks:
+- Memory bandwidth (BabelStream): 3648 GB/s
+- array\_size: 134217728
+- iterations: 100
+- precision: FP64
+
+## Usage
+
+If you do not already have an account on COSMA, please follow the instructions [here](account.md), then request to join the project: do018.
+
+- MI100 node is accessible through the `cosma8-shm2` queue.  Use `--nodelist=ga004` to ensure allocation to the MI100 node.
+- MI210 nodes are accessible through the `cosma8-shm2` queue.  Use `--exclude=ga004` to ensure allocation to the MI210 nodes.
+- MI300X node is accessible through the `mi300x` queue.
+- MI300A node is accessible through direct ssh.  From a login node, use `ssh ga008`.
+
+## Known issues / notes
+
+The AMD ROCm software stack is installed.  ROCm 6.3.0 is available at /opt/rocm-6.3.0/bin/hipcc
+
+CUDA code must be converted to HIP using the `hipify` script provided with ROCm.
+

--- a/docs/source/dine2.md
+++ b/docs/source/dine2.md
@@ -4,6 +4,8 @@ DINE2, the Durham Investigatory Node Environment (or Durham Integrated Next-gen 
 
 With dual Intel Sapphire Rapids 32-core processors and 2TB RAM.  Each node has access to up to 8 NVIDIA A30 GPUs, using a CerIO composable fabric.
 
+DINE2 was installed in 2024.
+
 ## Specifications
 
 | Nodes | RAM per node | CPU(s) | Network Technology | GPU | GPU Count |
@@ -36,6 +38,3 @@ CUDA is available as a module, using `module load nvhpc/25.11`.
 
 Dine2 nodes mount /dine, not /cosma5.  Copy any necessary files into /dine/data/\<project\>/\<username\>/
 
-## History
-
-DINE2 was installed in 2024.

--- a/docs/source/hardwarelab.md
+++ b/docs/source/hardwarelab.md
@@ -39,13 +39,13 @@ We maintain [multiple generations of GPU architecture](gpu.md) from multiple ven
 
 ### AMD GPU nodes
 
-We have multiple generations of AMD MI GPU:
+We have multiple generations of [AMD MI GPU](amdgpu.md):
 - MI100
 - MI210
 - MI300A
 - MI300X
 
-There are [two nodes](amdgpu.md), each with two AMD MI200 GPUs available.  Submit jobs to the cosma8-shm2 partition.  This partition also contains a node with one AMD MI100 GPU.  To specify a particular GPU to submit to, use --exclude or --include.
+There are two nodes, each with two AMD MI200 GPUs available.  Submit jobs to the cosma8-shm2 partition.  This partition also contains a node with one AMD MI100 GPU.  To specify a particular GPU to submit to, use --exclude or --include.
 
 For the MI300 GPUs, either submit to the mi300x queue, or ssh directly from a login node to the ga008 node (MI300X).
 


### PR DESCRIPTION
- Collated all the AMD GPU information into a single page, following the new template, with links to SHAREing.

I thought about having a completely separate page for each chip, but it's a lot of duplicate information, I think grouping by "hardware family" might be the best balance of specificity and page count.  Let me know if you disagree.