### PR TITLE
Consolidate Dine2 information

### DIFF
--- a/docs/source/dine2.md
+++ b/docs/source/dine2.md
@@ -11,6 +11,7 @@ DINE2 was installed in 2024.
 | Nodes | RAM per node | CPU(s) | Network Technology | GPU | GPU Count |
 | --- | --- | --- | --- | --- | --- |
 | 8 | 2TB | 2x Intel Sapphire Rapids 32-core | Infiniband | Nvidia A30 24GB | 8 Total (configurable) |
+|   |     |                                  |            | Nvidia V100 32GB | 4 Total (configurable) |
 
 By default, each node has a single GPU attached, but can be configured to use up to the 8 available.  
 To request a specific configuration, please contact `cosma-support@durham.ac.uk`.

--- a/docs/source/gpu.md
+++ b/docs/source/gpu.md
@@ -73,11 +73,9 @@ You can use the ```--include``` or ```--exclude``` SLURM parameters within your 
 
 ## Using the composable A30 and V100 GPUs
 
-The DINE2 cluster has 8 nodes, 8x A30 GPUs and 4x V100 GPUs.  The GPUs can be allowed to the nodes as required, depending on user workloads.
+The DINE2 cluster has 8 nodes, 8x A30 GPUs and 4x V100 GPUs.  The GPUs can be allocated to the nodes as required, depending on user workloads.
 
-You can use the ```--include``` or ```--exclude``` SLURM parameters within your batch script to specify particular nodes.  Or alternatively, to be given a node with a GPU (within the composable partition), you can use ```#SBATCH --constraint=gpu```.
-
-
+Further information on the DINE2 cluster can be found [here](dine2.md).
 
 ## GPU notes
 
@@ -88,14 +86,6 @@ To use some of these GPUs, you may need to be in the "video" or "render" groups 
 To check that you have the correct permissions to submit to a partition, you can use the ```scontrol show partition=PARTITION_NAME``` command to see which groups are allow to submit to that partition.
 
 The Intel PVC GPUs on gi001 are currently dead - sometime in Autumn 2025.  Watch this space - we may be able to resurrect them.
-
-## DINE2
-
-The DINE2 GPU system is a composable system with up to 8 A30 GPUs per node.  Currently these are static (i.e. if you require a specific GPU configuration, please ask), but eventually we hope to make it dynamic (i.e. to be able to ask Slurm to compose a system).  In total, there are 8 GPUs, and these can be composed in any configuration to the 8 servers.
-
-Each server has dual 32-core Sapphire Rapids CPUs (64 cores per node) and 2TB RAM.
-
-To use these nodes, submit jobs to the dine2 partition.
 
 ## Grace-Hopper
 

--- a/docs/source/tenstorrent.md
+++ b/docs/source/tenstorrent.md
@@ -17,6 +17,14 @@ Most tenstorrent commands start with tt.  To access many of these, you will need
 To install an updated software stack as a user, you may be able to follow the instructions here (though this may require root access):
 [https://docs.tenstorrent.com/getting-started/README.html](https://docs.tenstorrent.com/getting-started/README.html)
 
+### Resource sharing
+
+From our testing so far, tenstorrent cards appear to prefer jobs to be run serially.
+If a card is running an inference server, for example, it cannot also be used to run a tt-metalium
+program.
+
+We have not yet tested running multiple tt-metalium programs in parallel.
+
 ### tt-metalalium
 
 The tt-metalium library for c++ is installed on the machine, this is the low-level SDK for tenstorrent devices.


### PR DESCRIPTION
Taking more detailed information out of the main GPU page and linking to the DINE2 page instead.